### PR TITLE
Analisar e instruir sobre o uso do projeto

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -93,7 +93,7 @@ bandit>=1.7.0
 safety>=2.3.0
 
 # Mocks e Stubs
-unittest-mock>=1.0.0
+# unittest-mock>=1.0.0
 freezegun>=1.2.0
 
 # Relatórios e Cobertura


### PR DESCRIPTION
Remove `unittest-mock` from `requirements.txt` to fix `pip install` errors.

The `unittest-mock` package does not exist; `unittest.mock` is part of the Python standard library since version 3.3.

---
<a href="https://cursor.com/background-agent?bcId=bc-21a3ea48-ef62-46d0-a43c-fa20d7428879">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-21a3ea48-ef62-46d0-a43c-fa20d7428879">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

